### PR TITLE
Add options for SublimeLinter-contrib-verilator

### DIFF
--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -110,6 +110,7 @@ public:
 	IGNINC,		// Ignore include file for --lint-only (by Kris)
 	IGNMOD,		// Ignore module for --lint-only (by Kris)
 	IGNDEF,		// Ignore define for --lint-only (by Kris)
+	IGNUNUSED,	// Ignore unused warning for --lint-only (by Kris)
 	_ENUM_MAX
 	// ***Add new elements below also***
     };
@@ -144,7 +145,7 @@ public:
 	    "SELRANGE", "STMTDLY", "SYMRSVDWORD", "SYNCASYNCNET",
 	    "UNDRIVEN", "UNOPT", "UNOPTFLAT", "UNPACKED", "UNSIGNED", "UNUSED",
 	    "USERERROR", "USERFATAL", "USERINFO", "USERWARN",
-	    "VARHIDDEN", "WIDTH", "WIDTHCONCAT", "IGNINC", "IGNMOD", "IGNDEF",
+	    "VARHIDDEN", "WIDTH", "WIDTHCONCAT", "IGNINC", "IGNMOD", "IGNDEF", "IGNUNUSED",
 	    " MAX"
 	};
 	return names[m_e];

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -107,6 +107,8 @@ public:
 	VARHIDDEN,	// Hiding variable
 	WIDTH,		// Width mismatch
 	WIDTHCONCAT,	// Unsized numbers/parameters in concatenations
+	IGNINC,		// Ignore include file for --lint-only (by Kris)
+	IGNMOD,		// Ignore module for --lint-only (by Kris)
 	_ENUM_MAX
 	// ***Add new elements below also***
     };
@@ -141,7 +143,7 @@ public:
 	    "SELRANGE", "STMTDLY", "SYMRSVDWORD", "SYNCASYNCNET",
 	    "UNDRIVEN", "UNOPT", "UNOPTFLAT", "UNPACKED", "UNSIGNED", "UNUSED",
 	    "USERERROR", "USERFATAL", "USERINFO", "USERWARN",
-	    "VARHIDDEN", "WIDTH", "WIDTHCONCAT",
+	    "VARHIDDEN", "WIDTH", "WIDTHCONCAT", "IGNINC", "IGNMOD",
 	    " MAX"
 	};
 	return names[m_e];

--- a/src/V3Error.h
+++ b/src/V3Error.h
@@ -109,6 +109,7 @@ public:
 	WIDTHCONCAT,	// Unsized numbers/parameters in concatenations
 	IGNINC,		// Ignore include file for --lint-only (by Kris)
 	IGNMOD,		// Ignore module for --lint-only (by Kris)
+	IGNDEF,		// Ignore define for --lint-only (by Kris)
 	_ENUM_MAX
 	// ***Add new elements below also***
     };
@@ -143,7 +144,7 @@ public:
 	    "SELRANGE", "STMTDLY", "SYMRSVDWORD", "SYNCASYNCNET",
 	    "UNDRIVEN", "UNOPT", "UNOPTFLAT", "UNPACKED", "UNSIGNED", "UNUSED",
 	    "USERERROR", "USERFATAL", "USERINFO", "USERWARN",
-	    "VARHIDDEN", "WIDTH", "WIDTHCONCAT", "IGNINC", "IGNMOD",
+	    "VARHIDDEN", "WIDTH", "WIDTHCONCAT", "IGNINC", "IGNMOD", "IGNDEF",
 	    " MAX"
 	};
 	return names[m_e];

--- a/src/V3FileLine.cpp
+++ b/src/V3FileLine.cpp
@@ -242,12 +242,14 @@ void FileLine::modifyStateInherit(const FileLine* fromp) {
 void FileLine::v3errorEnd(ostringstream& str) {
     if (m_lineno) {
 	ostringstream nsstr;
-    if (m_igndef_lines.find(m_lineno) != m_igndef_lines.end()) { // by Kris, to indicate the same line as preproc error
-    string _str = str.str();
-    _str.insert(0, "[IGNDEF] ");
-    nsstr<<this<<_str;
-    } else
-	nsstr<<this<<str.str();
+    // by Kris, to indicate the same line as preproc error's
+    if (v3Global.opt.lintOnly()) {
+        if (m_igndef_lines.find(m_lineno) != m_igndef_lines.end()) {
+            string _str = str.str();
+            _str.insert(0, "[IGNDEF] ");
+            nsstr<<this<<_str;
+        } else nsstr<<this<<str.str();
+    } else nsstr<<this<<str.str();
 	if (warnIsOff(V3Error::errorCode())) V3Error::suppressThisWarning();
 	V3Error::v3errorEnd(nsstr);
     } else {

--- a/src/V3FileLine.cpp
+++ b/src/V3FileLine.cpp
@@ -34,7 +34,10 @@
 # include "V3Config.h"
 #endif
 
-set<int> FileLine::m_igndef_lines; // by Kris
+// by Kris
+set<int> FileLine::m_igndef;
+bool FileLine::m_ignmod;
+set<string> FileLine::m_ignunused;
 
 //######################################################################
 // FileLineSingleton class functions
@@ -244,7 +247,7 @@ void FileLine::v3errorEnd(ostringstream& str) {
 	ostringstream nsstr;
     // by Kris, to indicate the same line as preproc error's
     if (v3Global.opt.lintOnly()) {
-        if (m_igndef_lines.find(m_lineno) != m_igndef_lines.end()) {
+        if (m_igndef.find(m_lineno) != m_igndef.end()) {
             string _str = str.str();
             _str.insert(0, "[IGNDEF] ");
             nsstr<<this<<_str;

--- a/src/V3FileLine.cpp
+++ b/src/V3FileLine.cpp
@@ -34,6 +34,8 @@
 # include "V3Config.h"
 #endif
 
+set<int> FileLine::m_igndef_lines; // by Kris
+
 //######################################################################
 // FileLineSingleton class functions
 
@@ -240,6 +242,11 @@ void FileLine::modifyStateInherit(const FileLine* fromp) {
 void FileLine::v3errorEnd(ostringstream& str) {
     if (m_lineno) {
 	ostringstream nsstr;
+    if (m_igndef_lines.find(m_lineno) != m_igndef_lines.end()) { // by Kris, to indicate the same line as preproc error
+    string _str = str.str();
+    _str.insert(0, "[IGNDEF] ");
+    nsstr<<this<<_str;
+    } else
 	nsstr<<this<<str.str();
 	if (warnIsOff(V3Error::errorCode())) V3Error::suppressThisWarning();
 	V3Error::v3errorEnd(nsstr);

--- a/src/V3FileLine.h
+++ b/src/V3FileLine.h
@@ -76,8 +76,9 @@ class FileLine {
 
 public:
     // by Kris,
-    static set<int> m_igndef_lines; // to record preproc error lines
-    bool   m_dont_preproc; // to ignore submodule file
+    static set<int>    m_igndef;    // to record preproc error lines
+    static bool        m_ignmod;    // to ignore submodule file
+    static set<string> m_ignunused; // to ignore unused warnings
 
 private:
     struct EmptySecret {};

--- a/src/V3FileLine.h
+++ b/src/V3FileLine.h
@@ -75,7 +75,9 @@ class FileLine {
     bitset<V3ErrorCode::_ENUM_MAX>	m_warnOn;
 
 public:
-    static set<int> m_igndef_lines; // by Kris, to record preproc error lines
+    // by Kris,
+    static set<int> m_igndef_lines; // to record preproc error lines
+    bool   m_dont_preproc; // to ignore submodule file
 
 private:
     struct EmptySecret {};

--- a/src/V3FileLine.h
+++ b/src/V3FileLine.h
@@ -74,6 +74,9 @@ class FileLine {
     int		m_filenameno;
     bitset<V3ErrorCode::_ENUM_MAX>	m_warnOn;
 
+public:
+    static set<int> m_igndef_lines; // by Kris, to record preproc error lines
+
 private:
     struct EmptySecret {};
     inline static FileLineSingleton& singleton() {

--- a/src/V3LinkCells.cpp
+++ b/src/V3LinkCells.cpp
@@ -142,7 +142,7 @@ private:
 	    // We'll throw the error when we know the module will really be needed.
 	    string prettyName = AstNode::prettyName(modName);
 	    V3Parse parser (v3Global.rootp(), m_filterp, m_parseSymp);
-	    if (v3Global.opt.lintOnly()) nodep->fileline()->m_dont_preproc = true; // by Kris
+	    if (v3Global.opt.lintOnly()) nodep->fileline()->m_ignmod = true; // by Kris
 	    parser.parseFile(nodep->fileline(), prettyName, false, "");
 	    V3Error::abortIfErrors();
 	    // We've read new modules, grab new pointers to their names

--- a/src/V3LinkCells.cpp
+++ b/src/V3LinkCells.cpp
@@ -142,6 +142,7 @@ private:
 	    // We'll throw the error when we know the module will really be needed.
 	    string prettyName = AstNode::prettyName(modName);
 	    V3Parse parser (v3Global.rootp(), m_filterp, m_parseSymp);
+	    if (v3Global.opt.lintOnly()) nodep->fileline()->m_dont_preproc = true; // by Kris
 	    parser.parseFile(nodep->fileline(), prettyName, false, "");
 	    V3Error::abortIfErrors();
 	    // We've read new modules, grab new pointers to their names

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -411,6 +411,38 @@ private:
 	visitIterateNoValueMod(nodep);
     }
 
+    // by Kris, to prevent unused warnings for connected signals
+    virtual void visit(AstParseRef* nodep) {
+    	if (v3Global.opt.lintOnly()) {
+    		AstNode* pin;
+    		bool ispin = false;
+    		if (nodep->backp()->type() == AstType::atPin) {
+    			ispin = true;
+    			pin = nodep->backp();
+    		}
+    		else if (nodep->backp()->type() == AstType::atSelBit)
+    		if (nodep->backp()->backp()->type() == AstType::atPin) {
+    			ispin = true;
+    			pin = nodep->backp()->backp();
+    		}
+    		if (ispin) {
+    			AstNode* niterp;
+    			niterp = pin;
+    			while(niterp) {
+    				if (niterp->type() == AstType::atCell && ((AstCell*) niterp)->modp()->type() == AstType::atNotFoundModule) {
+    					FileLine::m_ignunused.insert(nodep->name());
+    					niterp = NULL;
+    				}
+    				else if (niterp->type() == AstType::atModule) niterp = NULL;
+    				else niterp = niterp->backp();
+    			}
+    		}
+    	}
+	// Default: Just iterate
+	cleanFileline(nodep);
+	nodep->iterateChildren(*this);
+    }
+
     virtual void visit(AstNode* nodep) {
 	// Default: Just iterate
 	cleanFileline(nodep);

--- a/src/V3ParseImp.cpp
+++ b/src/V3ParseImp.cpp
@@ -112,8 +112,8 @@ void V3ParseImp::parseFile(FileLine* fileline, const string& modfilename, bool i
     // Preprocess into m_ppBuffer
     // by Kris
     bool ok;
-    if (v3Global.opt.lintOnly() && fileline->m_dont_preproc) {
-        ok = false; fileline->m_dont_preproc = false;
+    if (v3Global.opt.lintOnly() && fileline->m_ignmod) {
+        ok = false; fileline->m_ignmod = false;
     } else {
         ok = V3PreShell::preproc(fileline, modfilename, m_filterp, this, errmsg);
     }

--- a/src/V3ParseImp.cpp
+++ b/src/V3ParseImp.cpp
@@ -110,7 +110,13 @@ void V3ParseImp::parseFile(FileLine* fileline, const string& modfilename, bool i
     }
 
     // Preprocess into m_ppBuffer
-    bool ok = V3PreShell::preproc(fileline, modfilename, m_filterp, this, errmsg);
+    // by Kris
+    bool ok;
+    if (v3Global.opt.lintOnly() && fileline->m_dont_preproc) {
+        ok = false; fileline->m_dont_preproc = false;
+    } else {
+        ok = V3PreShell::preproc(fileline, modfilename, m_filterp, this, errmsg);
+    }
     if (!ok) {
 	if (errmsg != "") return;  // Threw error already
 	// Create fake node for later error reporting

--- a/src/V3PreShell.cpp
+++ b/src/V3PreShell.cpp
@@ -114,11 +114,15 @@ protected:
     }
 
     void preprocInclude (FileLine* fl, const string& modname) {
-    fl->v3warn(IGNINC, "Ignore include file: "<<modname); // for --lint-only by Kris
-	/*if (modname[0]=='/' || modname[0]=='\\') {
-	    fl->v3warn(INCABSPATH,"Suggest `include with absolute path be made relative, and use +include: "<<modname);
-	}
-	preprocOpen(fl, s_filterp, modname, V3Os::filenameDir(fl->filename()), "Cannot find include file: ");*/
+        // by Kris
+        if (v3Global.opt.lintOnly()) {
+            fl->v3warn(IGNINC, "Ignore include file: "<<modname);
+        } else {
+        	if (modname[0]=='/' || modname[0]=='\\') {
+        	    fl->v3warn(INCABSPATH,"Suggest `include with absolute path be made relative, and use +include: "<<modname);
+        	}
+        	preprocOpen(fl, s_filterp, modname, V3Os::filenameDir(fl->filename()), "Cannot find include file: ");
+        }
     }
 
     bool preprocOpen (FileLine* fl, V3InFilter* filterp, const string& modname, const string& lastpath,

--- a/src/V3PreShell.cpp
+++ b/src/V3PreShell.cpp
@@ -114,7 +114,7 @@ protected:
     }
 
     void preprocInclude (FileLine* fl, const string& modname) {
-    fl->v3warn(IGNINC, "Ignore include fie: "<<modname); // for --lint-only by Kris
+    fl->v3warn(IGNINC, "Ignore include file: "<<modname); // for --lint-only by Kris
 	/*if (modname[0]=='/' || modname[0]=='\\') {
 	    fl->v3warn(INCABSPATH,"Suggest `include with absolute path be made relative, and use +include: "<<modname);
 	}

--- a/src/V3PreShell.cpp
+++ b/src/V3PreShell.cpp
@@ -114,10 +114,11 @@ protected:
     }
 
     void preprocInclude (FileLine* fl, const string& modname) {
-	if (modname[0]=='/' || modname[0]=='\\') {
+    fl->v3warn(IGNINC, "Ignore include fie: "<<modname); // for --lint-only by Kris
+	/*if (modname[0]=='/' || modname[0]=='\\') {
 	    fl->v3warn(INCABSPATH,"Suggest `include with absolute path be made relative, and use +include: "<<modname);
 	}
-	preprocOpen(fl, s_filterp, modname, V3Os::filenameDir(fl->filename()), "Cannot find include file: ");
+	preprocOpen(fl, s_filterp, modname, V3Os::filenameDir(fl->filename()), "Cannot find include file: ");*/
     }
 
     bool preprocOpen (FileLine* fl, V3InFilter* filterp, const string& modname, const string& lastpath,

--- a/src/V3Undriven.cpp
+++ b/src/V3Undriven.cpp
@@ -275,6 +275,13 @@ private:
 
     // VISITORS
     virtual void visit(AstVar* nodep) {
+
+    	bool pass = false; // by Kris
+    	if (v3Global.opt.lintOnly() && FileLine::m_ignunused.find(nodep->name()) != FileLine::m_ignunused.end()) {
+    		nodep->v3warn(IGNUNUSED, "Signal is unused. it is connected to NOTFOUNDMODULE: "<<nodep->prettyName());
+    		pass = true;
+    	}
+
 	for (int usr=1; usr<(m_alwaysp?3:2); ++usr) {
 	    // For assigns and non-combo always, do just usr==1, to look for module-wide undriven etc
 	    // For non-combo always, run both usr==1 for above, and also usr==2 for always-only checks
@@ -289,6 +296,10 @@ private:
 		|| nodep->isSigUserRdPublic()
 		|| (m_taskp && (m_taskp->dpiImport() || m_taskp->dpiExport()))) {
 		entryp->usedWhole();
+	    }
+	    if (pass) { // by Kris
+	    	entryp->drivenWhole();
+	    	entryp->usedWhole();
 	    }
 	}
 	// Discover variables used in bit definitions, etc

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2333,8 +2333,9 @@ private:
 		// We've resolved parameters and hit a module that we couldn't resolve.  It's
 		// finally time to report it.
 		// Note only here in V3Width as this is first visitor after V3Dead.
-		nodep->v3error("Cannot find file containing module: "<<nodep->modName());
-		v3Global.opt.filePathLookedMsg(nodep->fileline(), nodep->modName());
+        nodep->v3warn(IGNMOD, "Cannot find file containing module: "<<nodep->modName());
+		/*nodep->v3error("Cannot find file containing module: "<<nodep->modName());
+		v3Global.opt.filePathLookedMsg(nodep->fileline(), nodep->modName());*/
 	    }
 	    if (nodep->rangep()) {
 		m_cellRangep = nodep->rangep();

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -542,7 +542,7 @@ private:
 	    // Note width() not set on range; use elementsConst()
 	    if (nodep->littleEndian() && !nodep->backp()->castUnpackArrayDType()
 		&& !nodep->backp()->castCell()) {  // For cells we warn in V3Inst
-		nodep->v3warn(LITENDIAN,"Little bit endian vector: MSB < LSB of bit range: "<<nodep->lsbConst()<<":"<<nodep->msbConst());
+        nodep->v3warn(LITENDIAN,"Little bit endian vector: MSB < LSB of bit range: "<<nodep->lsbConst()<<":"<<nodep->msbConst());
 	    }
 	}
     }
@@ -2333,7 +2333,7 @@ private:
 		// We've resolved parameters and hit a module that we couldn't resolve.  It's
 		// finally time to report it.
 		// Note only here in V3Width as this is first visitor after V3Dead.
-        nodep->v3warn(IGNMOD, "Cannot find file containing module: "<<nodep->modName());
+        nodep->v3warn(IGNMOD, "Ignore module: "<<nodep->modName()); // by Kris, for --lint-only
 		/*nodep->v3error("Cannot find file containing module: "<<nodep->modName());
 		v3Global.opt.filePathLookedMsg(nodep->fileline(), nodep->modName());*/
 	    }

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -2333,9 +2333,13 @@ private:
 		// We've resolved parameters and hit a module that we couldn't resolve.  It's
 		// finally time to report it.
 		// Note only here in V3Width as this is first visitor after V3Dead.
-        nodep->v3warn(IGNMOD, "Ignore module: "<<nodep->modName()); // by Kris, for --lint-only
-		/*nodep->v3error("Cannot find file containing module: "<<nodep->modName());
-		v3Global.opt.filePathLookedMsg(nodep->fileline(), nodep->modName());*/
+            // by Kris
+            if (v3Global.opt.lintOnly()) {
+                nodep->v3warn(IGNMOD, "Ignore module: "<<nodep->modName());
+            } else {
+                nodep->v3error("Cannot find file containing module: "<<nodep->modName());
+                v3Global.opt.filePathLookedMsg(nodep->fileline(), nodep->modName());
+            }
 	    }
 	    if (nodep->rangep()) {
 		m_cellRangep = nodep->rangep();

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -32,6 +32,10 @@
 extern void yyerror(const char*);
 extern void yyerrorf(const char* format, ...);
 
+// by Kris
+extern void yywarn(const char*);
+extern void yywarnf(const char* format, ...);
+
 #define STATE_VERILOG_RECENT  S17  // State name for most recent Verilog Version
 
 #define PARSEP V3ParseImp::parsep()
@@ -142,6 +146,25 @@ void yyerrorf(const char* format, ...) {
     va_end(ap);
 
     yyerror(msg);
+}
+
+// by Kris
+void yywarn(const char* errmsg) {
+    PARSEP->fileline()->v3warn(IGNDEF, errmsg);
+    FileLine::m_igndef_lines.insert(PARSEP->fileline()->lineno()); // record line number
+}
+
+void yywarnf(const char* format, ...) {
+    const int maxlen = 2000;
+    char msg[maxlen];
+
+    va_list ap;
+    va_start(ap,format);
+    VL_VSNPRINTF(msg,maxlen,format,ap);
+    msg[maxlen-1] = '\0';
+    va_end(ap);
+
+    yywarn(msg);
 }
 
 /**********************************************************************/
@@ -1008,7 +1031,7 @@ vnum	{vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   /* Default rules - leave last */
 
 <V95,V01,V05,VA5,S05,S09,S12,S17,SAX,VLT>{
-  "`"[a-zA-Z_0-9]+	{ FL; yyerrorf("Define or directive not defined: %s",yytext); }
+  "`"[a-zA-Z_0-9]+	{ FL; yywarnf("Define or directive not defined: %s",yytext); } /* error->warn by Kris */
   "//"[^\n]*		{ }  /* throw away single line comments */
   .			{ FL; return yytext[0]; }	/* return single char ops. */
 }

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -151,7 +151,7 @@ void yyerrorf(const char* format, ...) {
 // by Kris
 void yywarn(const char* errmsg) {
     PARSEP->fileline()->v3warn(IGNDEF, errmsg);
-    FileLine::m_igndef_lines.insert(PARSEP->fileline()->lineno()); // record line number
+    FileLine::m_igndef.insert(PARSEP->fileline()->lineno()); // record line number
 }
 
 void yywarnf(const char* format, ...) {

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -1031,7 +1031,7 @@ vnum	{vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   /* Default rules - leave last */
 
 <V95,V01,V05,VA5,S05,S09,S12,S17,SAX,VLT>{
-  "`"[a-zA-Z_0-9]+	{ FL; yywarnf("Define or directive not defined: %s",yytext); } /* error->warn by Kris */
+  "`"[a-zA-Z_0-9]+	{ FL; if (v3Global.opt.lintOnly()) yywarnf("Define or directive not defined: %s",yytext); else yyerrorf("Define or directive not defined: %s",yytext); } /* error->warn by Kris */
   "//"[^\n]*		{ }  /* throw away single line comments */
   .			{ FL; return yytext[0]; }	/* return single char ops. */
 }


### PR DESCRIPTION
Get `https://github.com/poucotm/SublimeLinter-contrib-verilator.git`.
Update `linter.py`; e.g `~/Library/Application\ Support/Sublime\ Text\ 3/Packages/SublimeLinter-contrib-verilator/linter.py`
With this:
```
from SublimeLinter.lint import Linter, STREAM_STDERR

class Verilator(Linter):
    """Provides an interface to verilator."""

    cmd = 'verilator_bin --lint-only $temp_file'

    tempfile_suffix = 'verilog'
    error_stream = STREAM_STDERR
    regex = (
        r'^%(?:(?P<warning>Warning)|(?P<error>Error))(?P<code>[-\w]*): '
        r'[^:]*:(?P<line>[0-9]+): '
        r'(?P<message>.*)$'
    )

    defaults = {
        'selector': 'source.verilog, source.systemverilog'
    }
```